### PR TITLE
add categores_id attribute

### DIFF
--- a/lib/kaltura/kaltura_client.rb
+++ b/lib/kaltura/kaltura_client.rb
@@ -87,6 +87,7 @@ module Kaltura
 		attr_accessor :tags
 		attr_accessor :admin_tags
 		attr_accessor :categories
+		attr_accessor :categories_ids
 		attr_accessor :status
 		attr_accessor :moderation_status
 		attr_accessor :moderation_count


### PR DESCRIPTION
new categories_id attribute is now returned as part of the media list service
